### PR TITLE
add shutdown reason file support

### DIFF
--- a/Config.cpp
+++ b/Config.cpp
@@ -163,18 +163,16 @@ Config::Config(std::filesystem::path configFile)
     installPath_.make_preferred();
     jRlsInstall.at("identity").get_to(installIdentity_);
 
-    // paths
-    const auto& jRlsPaths{jRls.at("paths")};
-    jRlsPaths.at("cache").get_to(pathsCache_);
-    pathsCache_.make_preferred();
-    jRlsPaths.at("download").get_to(pathsDownload_);
-    pathsDownload_.make_preferred();
-
     // process
     if (jRls.contains("process"))
     {
       const auto& jRlsProcess{jRls.at("process")};
       GetOptionalValueTo(processAutoRestart_, jRlsProcess, "autoRestart");
+      if (jRlsProcess.contains("reasonPath"))
+      {
+        jRlsProcess.at("reasonPath").get_to(processReasonPath_);
+        processReasonPath_.make_preferred();
+      }
       // default optional integer to zero
       GetOptionalValueTo(
         processShutdownDelaySeconds_, jRlsProcess, "shutdownDelaySeconds");

--- a/Config.h
+++ b/Config.h
@@ -19,6 +19,16 @@ class Config
 public:
 
   enum class ModFrameworkType { NONE, CARBON, OXIDE };
+  static std::string ToString(const ModFrameworkType type)
+  {
+    switch (type)
+    {
+      case ModFrameworkType::NONE:   return "None";
+      case ModFrameworkType::CARBON: return "Carbon";
+      case ModFrameworkType::OXIDE:  return "Oxide";
+    }
+    return "Unknown";
+  }
 
   enum class SeedStrategy { FIXED, LIST, RANDOM };
 
@@ -84,12 +94,10 @@ public:
     { return installPath_; }
   std::string           GetInstallIdentity()                     const
     { return installIdentity_; }
-  std::filesystem::path GetPathsCache()                          const
-    { return pathsCache_; }
-  std::filesystem::path GetPathsDownload()                       const
-    { return pathsDownload_; }
   bool                  GetProcessAutoRestart()                  const
     { return processAutoRestart_; }
+  std::filesystem::path GetProcessReasonPath()                   const
+    { return processReasonPath_; }
   int                   GetProcessShutdownDelaySeconds()         const
     { return processShutdownDelaySeconds_; }
   std::string           GetRconPassword()                        const
@@ -149,9 +157,8 @@ private:
 
   std::filesystem::path installPath_ = {};
   std::string           installIdentity_ = {};
-  std::filesystem::path pathsCache_ = {};
-  std::filesystem::path pathsDownload_ = {};
   bool                  processAutoRestart_ = {};
+  std::filesystem::path processReasonPath_ = {};
   int                   processShutdownDelaySeconds_ = {};
   std::string           rconPassword_ = {};
   std::string           rconIP_ = {};

--- a/Server.cpp
+++ b/Server.cpp
@@ -218,7 +218,7 @@ Server::~Server()
   {
     try
     {
-      Stop("Unexpected server manager failure");
+      Stop();
     }
     catch (const std::exception& e)
     {

--- a/Server.h
+++ b/Server.h
@@ -87,7 +87,7 @@ public:
   ///  Does nothing if the server is already stopped.
   /// @param reason Optional shutdown reason, provided to anyone monitoring
   ///  the server (online players, Discord integrations, etc.)
-  void Stop(const std::string& reason = {});
+  void Stop(const std::string& reason = "Unexpected server manager failure");
 
 private:
 

--- a/Updater.cpp
+++ b/Updater.cpp
@@ -354,7 +354,6 @@ Updater::Updater(
   , serverInstallPath_(cfgSptr->GetInstallPath())
   , appManifestPath_(cfgSptr->GetInstallPath() / "steamapps/appmanifest_258550.acf")
   , steamCmdPath_(cfgSptr->GetSteamcmdPath())
-  , downloadPath_(cfgSptr->GetPathsDownload())
   , frameworkDllPath_(GetFrameworkDllPath(
       serverInstallPath_, cfgSptr->GetUpdateModFrameworkType()))
 {
@@ -405,23 +404,7 @@ Updater::Updater(
     !frameworkDllPath_.empty() && !std::filesystem::exists(frameworkDllPath_))
   {
     std::cout << "WARNING: Modding framework DLL '" << frameworkDllPath_ << "' not found; automatic " << ToString(cfgSptr->GetUpdateModFrameworkType(), ToStringCase::TITLE) << " updates disabled\n";
-    downloadPath_.clear();
     frameworkDllPath_.clear();
-  }
-  if (!frameworkDllPath_.empty())
-  {
-    if (!IsDirectory(downloadPath_))
-    {
-      std::cout << "WARNING: Configured download path " << downloadPath_ << " is not a directory; automatic " << ToString(cfgSptr->GetUpdateModFrameworkType(), ToStringCase::TITLE) << " updates disabled\n";
-      downloadPath_.clear();
-      frameworkDllPath_.clear();
-    }
-    else if (!IsWritable(downloadPath_))
-    {
-      std::cout << "WARNING: Configured download path " << downloadPath_ << " is not writable; automatic " << ToString(cfgSptr->GetUpdateModFrameworkType(), ToStringCase::TITLE) << " updates disabled\n";
-      downloadPath_.clear();
-      frameworkDllPath_.clear();
-    }
   }
 
   // std::cout << "Updater initialized. Server updates " << (serverUpdateCheck_ ? "enabled" : "disabled") << ". Oxide updates " << (oxideUpdateCheck_ ? "enabled" : "disabled")<< "\n";
@@ -482,9 +465,9 @@ void Updater::UpdateFramework(const bool suppressWarning) const
   }
 
   // abort if any required path is empty, meaning it failed validation
-  if (downloadPath_.empty() || serverInstallPath_.empty())
+  if (serverInstallPath_.empty())
   {
-    std::cout << "ERROR: Cannot update " << frameworkTitle << " because download and/or server install path is invalid\n";
+    std::cout << "ERROR: Cannot update " << frameworkTitle << " because server install path is invalid\n";
     return;
   }
 

--- a/Updater.h
+++ b/Updater.h
@@ -130,8 +130,6 @@ private:
   std::filesystem::path appManifestPath_;
   // path to SteamCMD binary as reported by manifest file
   std::filesystem::path steamCmdPath_;
-  // directory in which modding framework downloads should be temporarily stored
-  std::filesystem::path downloadPath_;
   // path to Carbon/Oxide modding framework DLL derived from server install path
   // may be empty if not installed, and/or modding framework updating disabled
   std::filesystem::path frameworkDllPath_;

--- a/exampleConfig.jsonc
+++ b/exampleConfig.jsonc
@@ -29,25 +29,6 @@
       //  - Used internally and passed to server as `+server.identity`.
       "identity": "server1"
     },
-    // Required group: rustLaunchSite path settings.
-    "paths":
-    {
-      // Required string: File that rustLaunchSite should use to cache data that
-      //  needs to persist across runs (e.g. last used seed settings, last seen
-      //  client-server protocol version, etc.).
-      // NOTES:
-      //  - rustLaunchSite must have the ability to read and write this file.
-      //  - rustLaunchSite will attempt to create this file as needed if it does
-      //     not exist.
-      "cache": "C:/Games/rustserver/rustLaunchSite/rlscache.cfg",
-      // Required string: Directory that rustLaunchSite should use for temporary
-      //  downloads (e.g. Carbon/Oxide releases).
-      // NOTES:
-      //  - Directory must exist, or errors / reduced functionality may occur.
-      //  - rustLaunchSite must have the ability to create and delete files in
-      //     this directory as needed.
-      "download": "C:/Games/rustserver/rustLaunchSite"
-    },
     // Optional group: Server process (re)start/shutdown settings; if omitted,
     //  the contained settings will be considered disabled.
     // NOTE: See `rustDedicated` section for sever command-line parameter
@@ -62,6 +43,17 @@
       // NOTE: This is equivalent to the `goto` feature commonly used in shell
       //  scripts to help keep a server running.
       "autoRestart": true,
+      // Optional string: Path to file containing a reason why a rustLaunchSite
+      //  termination is causing the server to shut down. This is intended to
+      //  facilitate things like daily restarts that can be implemented by
+      //  restarting rustLaunchSite on a schedule. If omitted, rustLaunchSite
+      //  will explain that the server shutdown is occurring due to its server
+      //  manager being stopped.
+      // NOTES:
+      //  - File will not be read until rustLaunchSite receives a shutdown
+      //     stimulus.
+      //  - File will be deleted on read, to avoid confusion.
+      "reasonPath": "C:\\Games\\rustLaunchSite\\reason.txt",
       // Optional integer: A positive value if rustLaunchSite-managed server
       //  shutdowns should be announced and delayed by up to the specified
       //  number of seconds when players are online, in order to give them a
@@ -357,7 +349,7 @@
       // true to suppress GUI.
       "batchmode": true,
       // path/name of server log file.
-      "logfile": "C:/Games/rustserver/log.txt",
+      "logfile": "C:\\Games\\rustserver\\log.txt",
       // don't initialize a graphics device (allows running without a GPU).
       "nographics": true,
       // true to suppress crash dialog.


### PR DESCRIPTION
- Config:
  - remove "paths" config attributes and API, as they're unused
  - add "process.reasonPath" config attribute
  - add ToString(ModFrameworkType)
  - add GetProcessReasonPath() API
- Server:
  - remove parameter from destructor Stop() call
  - add a default reason parameter value to Stop()
- Updater:
  - remove downloadPath processing and member variable
- exampleConfig.jsonc:
  - remove "paths" section
  - add "reasonPath" option
  - cleanup
- main.cpp:
  - add GetShutdownReason() to get reason text from configured file if present
  - use GetShutdownReason() for shutdowns triggered by Ctrl+C and final exit
  - add detail to update reason